### PR TITLE
Separation layouts, back to top, rework about/getting_started

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -108,7 +108,7 @@ footer
   z-index: 1
   display: block
 
-.scrollToTop
+.scroll-to-top
   margin: 0
   position: fixed
   bottom: 1%
@@ -116,5 +116,10 @@ footer
   text-decoration: none
   border-radius: 40%
 
-.backtop
+.back-top
   border-radius: 40%
+
+.img-keep-calm
+  height: 17%
+  border-radius: 3rem
+  margin-left: 5rem

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -81,10 +81,6 @@ h2, h3
     border-radius: 90%
   .littlemsg
     line-height: 2rem
-    font-style: italic
-    font-size: 0.7rem
-    color: rgb(170, 162, 165)
-
 
 .right-nav
   h2:first-child
@@ -111,3 +107,14 @@ footer
   left: auto
   z-index: 1
   display: block
+
+.scrollToTop
+  margin: 0
+  position: fixed
+  bottom: 1%
+  left: 1%
+  text-decoration: none
+  border-radius: 40%
+
+.backtop
+  border-radius: 40%

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  layout "applicationrightnav"
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  layout "applicationrightnav"
+  layout "application_right_nav"
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -30,6 +30,10 @@ class ComponentsController < ApplicationController
     @users = User.all.limit(3).table_search_pagination(params, session)
   end
 
+  def tables_cards
+    @users = User.all.limit(3).table_search_pagination(params, session)
+  end
+
   def core
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,7 @@ class HomeController < ApplicationController
   end
 
   def get_started
+    layout 'application'
   end
 
 end

--- a/app/views/components/tables_cards.html.haml
+++ b/app/views/components/tables_cards.html.haml
@@ -1,10 +1,11 @@
+// WORK IN PROGRESS
 :markdown
   # Tables cards
 
   Le composant `table_card` peut comporter:
 
   * une pagination
-  * une recherche
+  * une url
 
   La pagination est gérée grâce à la gem `will_paginate`.
 
@@ -15,3 +16,32 @@
     #### Important
     Pour ajouter, modifier, supprimer des colonnes et des actions dans le component
     `table_card` vous devez ajouter l'option `tap: true`.
+
+- @sections = sections do |s|
+  - s.section title: "View" do
+    :markdown
+      Les colonnes sont par défaut toutes affichées et les actions par défaut sont:
+
+      * show
+      * edit
+      * delete
+    = example do |c|
+      - c.header do
+        = table_card({ store: @users, tap: true }) do |b|
+          - b.columns do |cls|
+            - cls.column :id
+            - cls.column :email
+            - cls.column :active
+            - cls.column :company
+            - cls.column :created_at
+            - cls.column :updated_at
+          - b.actions do |acs|
+            - acs.link 'Show', url: '#show', glyph: 'eye'
+            - acs.link 'Edit', url: '#show', glyph: 'pencil'
+            - acs.link 'Delete', url: '#show', glyph: 'trash',  link_html_options: { data: { confirm: 'Are you sure?' }}
+      - c.code do
+        table_card({ store: @users, tap: true })
+      - c.footer do
+        = documentation_link 'Documentation', '#'
+
+= @sections.render

--- a/app/views/home/about.html.haml
+++ b/app/views/home/about.html.haml
@@ -1,8 +1,25 @@
-:markdown
-  # About
+= col ({ num: 12 }) do
+  :markdown
+    # About
 
-  ![Ui Bibz logo](http://hummel.link/Ui-Bibz/1.2.3/images/ui-bibz-logo-without-border.gif)
+    ![Ui Bibz logo](http://hummel.link/Ui-Bibz/1.2.3/images/ui-bibz-logo-without-border.gif)
 
-  ![http://badge.fury.io/rb/ui_bibz](https://badge.fury.io/rb/ui_bibz.svg) ![https://travis-ci.org/thooams/Ui-Bibz](https://travis-ci.org/thooams/Ui-Bibz.svg) ![https://codeclimate.com/github/thooams/Ui-Bibz](https://codeclimate.com/github/thooams/Ui-Bibz/badges/gpa.svg) ![https://codeclimate.com/github/thooams/Ui-Bibz](https://codeclimate.com/github/thooams/Ui-Bibz/badges/coverage.svg) ![http://inch-ci.org/github/thooams/Ui-Bibz](http://inch-ci.org/github/thooams/Ui-Bibz.svg?branch=master) ![https://hakiri.io/github/thooams/Ui-Bibz/master](https://hakiri.io/github/thooams/Ui-Bibz/master.svg) ![https://gemnasium.com/thooams/Ui-Bibz](https://gemnasium.com/thooams/Ui-Bibz.svg)
+    **Ui Bibz** -> ![http://badge.fury.io/rb/ui_bibz](https://badge.fury.io/rb/ui_bibz.svg) ![https://travis-ci.org/thooams/Ui-Bibz](https://travis-ci.org/thooams/Ui-Bibz.svg) ![https://codeclimate.com/github/thooams/Ui-Bibz](https://codeclimate.com/github/thooams/Ui-Bibz/badges/gpa.svg) ![https://codeclimate.com/github/thooams/Ui-Bibz](https://codeclimate.com/github/thooams/Ui-Bibz/badges/coverage.svg) ![http://inch-ci.org/github/thooams/Ui-Bibz](http://inch-ci.org/github/thooams/Ui-Bibz.svg?branch=master) ![https://hakiri.io/github/thooams/Ui-Bibz/master](https://hakiri.io/github/thooams/Ui-Bibz/master.svg) ![https://gemnasium.com/thooams/Ui-Bibz](https://gemnasium.com/thooams/Ui-Bibz.svg)
 
-  This project rocks and uses MIT-LICENSE.
+    **Ruby On Rails** -> [![Ruby On Rails Version](https://badge.fury.io/rb/rails.svg)](https://badge.fury.io/rb/rails)
+
+    **Bootstrap** -> [![Bootstrap Version](https://badge.fury.io/rb/bootstrap.svg)](https://badge.fury.io/rb/bootstrap)
+
+    This project rocks and uses MIT-LICENSE.
+
+    ## History
+
+    Originally, **Ui Bibz** was created by [Thomas HUMMEL](http://hummel.link/ "Thomas HUMMEL WebSite"), a French Ruby developer who want to create a library facilitating the use of the [Bootstrap](http://getbootstrap.com/ "Bootstrap") framework in **Ruby On Rails** projects, so he launched the [Open Source](https://github.com/thooams/Ui-Bibz "Ui Bibz on GitHub") project **Ui Bibz** on September 5, 2015.
+
+    Ui Bibz developed in **Ruby** with the **Ruby On Rails** framework.
+
+    New components are added regularly to offer more choice than official components provided by **Bootstrap**.
+
+    We are listening and open to suggestions from users of the library, so you can suggest new components or modifications of existing components from the [project issues](https://github.com/thooams/Ui-Bibz/issues "Issues Ui Bibz Git Hub") it's an **Open Source** project !
+
+    You can also suggest improvements to the documentation in the [same way](https://github.com/thooams/ui-bibz-app/issues "Documentation Ui Bibz Git Hub") !

--- a/app/views/home/getting_started.html.haml
+++ b/app/views/home/getting_started.html.haml
@@ -1,29 +1,40 @@
-:markdown
-  # Getting Started
-  ##Install
+= col ({ num: 2, pull: 2 }) do
+  = image_tag "http://img11.hostingpics.net/pics/936928keepcalmandletsgodevelop.png", :style => "height: 17%; border-radius: 3rem; margin-left: 5rem;"
+/ If you want delete the image, put 'offset: 2' in col (see example below the line) and remove the two lines above
+/= col ({ num: 6, offset: 2 }) do
+= col ({ num: 6 }) do
+  :markdown
+    # Getting Started
+    ##Install
 
-  Add this line in your Gemfile:  `gem "ui_bibz", '~> #{ UiBibzApp::Application::VERSION }'`
+    Add this line in your Gemfile:  `gem "ui_bibz", '~> #{ UiBibzApp::Application::VERSION }'`
 
-  Run this command: `bundle install`
+    Run this command: `bundle install`
 
-  ##Assets Install
+    ##Assets Install
 
-  Put this line in: /app/assets/stylesheets/applications.css
+    Put this line in: `/app/assets/stylesheets/applications.css`
 
+    `*= require ui_bibz`
 
-            ...
-            *= require ui_bibz
-            ...
+    Put this line in: `/app/assets/javascripts/applications.js`
 
-  Put this line in: `/app/assets/javascripts/applications.js`
+    `//= require ui_bibz`
 
-            ...
-            //= require ui_bibz
-            ...
+    _Ps: You can use sass variables into Boostrap._
 
-  _Ps: You can use sass variables into Boostrap._
+=col ({ num: 4 }) do
+  %div{ :style => "margin: 6rem 0 3rem 0;" }
+    :markdown
 
-  ##Simple form
+      ##Compatibility
 
-  Gem is compatible with  [simple_form](https://github.com/plataformatec/simple_form).
-  All inputs fields can be used with **simple_form**.
+      Gem is compatible with [**Ruby**](https://www.ruby-lang.org/ "Ruby") version 2.x.x and [**Ruby On Rails**](http://rubyonrails.org/ "Rails") 4.2.x.
+
+  %div
+    :markdown
+
+      ##Simple form
+
+      Gem is compatible with  [simple_form](https://github.com/plataformatec/simple_form).
+      All inputs fields can be used with **simple_form**.

--- a/app/views/home/getting_started.html.haml
+++ b/app/views/home/getting_started.html.haml
@@ -1,5 +1,5 @@
 = col ({ num: 2, pull: 2 }) do
-  = image_tag "http://img11.hostingpics.net/pics/936928keepcalmandletsgodevelop.png", :style => "height: 17%; border-radius: 3rem; margin-left: 5rem;"
+  = image_tag "http://img11.hostingpics.net/pics/936928keepcalmandletsgodevelop.png", :class => "img-keep-calm"
 / If you want delete the image, put 'offset: 2' in col (see example below the line) and remove the two lines above
 /= col ({ num: 6, offset: 2 }) do
 = col ({ num: 6 }) do

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -5,7 +5,7 @@
     - n.link glyph_and_text('diamond', 'Gem'), url: 'https://rubygems.org/gems/ui_bibz'
   :markdown
     Ui Bibz Framework is designed and created by Thomas HUMMEL ([@thooams](https://github.com/thooams))<br />
-    This theme is inspired by ["Bootstrap theme documentation"](http://getbootstrap.com)<br />
+    This theme is inspired by [Bootstrap theme documentation](http://getbootstrap.com)<br />
     Currently v#{ UiBibz::VERSION }. Code licensed MIT
   %form{ action: "https://www.paypal.com/cgi-bin/webscr", method: "post", target: "_top" }
     %input{ type: "hidden", name: "cmd", value: "_s-xclick" }

--- a/app/views/layouts/application_right_nav.html.haml
+++ b/app/views/layouts/application_right_nav.html.haml
@@ -26,6 +26,6 @@
               - @sections.names.each do |s|
                 - n.link s
 
-      .scrollToTop
-        = button_link "", { url: "##{ @sections.names.first.parameterize }", glyph: "arrow-circle-up", size: :lg, state: :info, type: 'fw' }, { class: "backtop" }
+      .scroll-to-top
+        = button_link "", { url: "##{ @sections.names.first.parameterize }", glyph: "arrow-circle-up", size: :lg, state: :info, type: 'fw' }, { class: "back-top" }
     = render "layouts/footer"

--- a/app/views/layouts/applicationrightnav.html.haml
+++ b/app/views/layouts/applicationrightnav.html.haml
@@ -15,5 +15,17 @@
           input groups, navigation, alerts, and much more.
     = container do
       = row do
-        = yield
+        = col num: 9 do
+          = yield
+        = col({ num: 3 }, { class: 'right-nav' }) do
+          = render "components/nav"
+          = yield :third_nav
+          - unless @sections.nil?
+            %h2 Contents
+            = subnav class: 'secondary-nav' do |n|
+              - @sections.names.each do |s|
+                - n.link s
+
+      .scrollToTop
+        = button_link "", { url: "##{ @sections.names.first.parameterize }", glyph: "arrow-circle-up", size: :lg, state: :info, type: 'fw' }, { class: "backtop" }
     = render "layouts/footer"


### PR DESCRIPTION
- Add back to top button in component applicationrightnav layout and css
- Little correction in footer layout
- Separation layouts : right nav only on the pages of components
- Rework of about and getting_started pages
- tables_cards page in progress